### PR TITLE
Part 5: Lifecycle Hooks and Reactivation

### DIFF
--- a/dinosure_course_klensch/.root-config.json
+++ b/dinosure_course_klensch/.root-config.json
@@ -20,7 +20,7 @@
     "policySchemeType": "individual",
     "dashboardIssuingEnabled": true,
     "activatePoliciesOnEvent": "policy_issued",
-    "canReactivatePolicies": false,
+    "canReactivatePolicies": true,
     "notTakenUpEnabled": false,
     "welcomeLetterEnabled": true,
     "policyDocuments": [

--- a/dinosure_course_klensch/code/07-reactivation-flow.js
+++ b/dinosure_course_klensch/code/07-reactivation-flow.js
@@ -1,1 +1,54 @@
 // 07-reactivation-flow
+
+/**
+ * Get the reactivation options for inactive policies.
+ * @param {PlatformPolicy} policy The policy to be reactivated.
+ * @return {ReactivationOption[]} One of these options must be selected whenever an inactive policy is reactivated.
+ */
+const getReactivationOptions = (policy) => {
+  return [
+    new ReactivationOption({
+      type: 'reinstatement',
+      description:
+        'We will reinstate your policy and collect the outstanding premium from you.',
+      minimumBalanceRequired: false,
+      settlementAmount: 0,
+    }),
+  ];
+};
+
+/**
+ * Executed before a policy is reactivated.
+ * Can be used to prevent reactivation if certain conditions are not met.
+ * @param {object} params
+ * @param {PlatformPolicy} params.policy The policy to be reactivated
+ * @param {PlatformPolicyholder} params.policyholder The policyholder linked to the policy
+ * @param {ReactivationOption} params.reactivationOption The reactivation option selected
+ * @return {ProductModuleAction[] | void} The actions to be queued by the platform
+ */
+const beforePolicyReactivated = ({
+  policy,
+  policyholder,
+  reactivationOption,
+}) => {
+  const { status } = policy;
+  if (status !== 'cancelled' && status !== 'lapsed') {
+    throw new Error(
+      'This policy cannot be reactivated - it is not cancelled or lapsed status.',
+    );
+  }
+
+  const updatedModuleData = {
+    ...policy.module,
+    reactivation_date: moment().format(),
+  };
+
+  return [
+    {
+      name: 'update_policy',
+      data: {
+        module: updatedModuleData,
+      },
+    },
+  ];
+};

--- a/dinosure_course_klensch/code/unit-tests/04-reactivation-data.js
+++ b/dinosure_course_klensch/code/unit-tests/04-reactivation-data.js
@@ -1,0 +1,14 @@
+const reactivationPolicyActive = {
+  status: 'active',
+  module: {},
+};
+
+const reactivationPolicyLapsed = {
+  status: 'lapsed',
+  module: {},
+};
+
+const reactivationPolicyCancelled = {
+  status: 'cancelled',
+  module: {},
+};

--- a/dinosure_course_klensch/code/unit-tests/05-reactivation-tests.js
+++ b/dinosure_course_klensch/code/unit-tests/05-reactivation-tests.js
@@ -1,0 +1,81 @@
+/* global expect moment ReactivationOption InvalidRequestError AlteredPolicy AlterationPackage QuotePackage Application Policy generatePolicyNumber Joi RequotePolicy root */
+
+describe('Reactivation flow', () => {
+  // Setup
+  let reactivationOption;
+
+  before(() => {
+    // @ts-ignore
+    reactivationOption = getReactivationOptions(reactivationPolicyCancelled)[0];
+  });
+
+  // Quote hook
+  describe('Before reactivation', () => {
+    it('should return an error because the policy is already active', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyActive,
+          policyholder: null,
+          reactivationOption: null,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.not.equal(null);
+    });
+
+    it('should return without error: lapsed policy', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyLapsed,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+    });
+
+    it('should return without error: cancelled policy', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyCancelled,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+    });
+
+    it('should return update_action with the reactivation date', () => {
+      let error = null;
+      let actions = null;
+      try {
+        actions = beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyCancelled,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+
+      // test that the actions return with the update_policy action and the reactivation date
+      expect(actions).to.not.equal(null);
+      expect(actions[0]).to.not.equal(null);
+      expect(actions[0].name).to.equal('update_policy');
+      expect(actions[0].data.module.reactivation_date).to.not.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
### Which part of the onboarding is this for?

- [ ] Part 1: Getting Set Up with Your First Product
- [ ] Part 2: Generating Insurance Quotes
- [ ] Part 3: Issuing Policies
- [ ] Part 4: Amending Policies with Alteration Hooks
- [x] Part 5: Lifecycle Hooks and Reactivation
- [ ] Part 6: Scheduled Functions and Anniversary Logic
- [ ] Part 7: Crafting Documents and Documentation
- [ ] Part 8: Building a Claims and Payout Flow

### What has been implemented in this PR?

Add Reactivation Logic

### How was testing done?

**Types of tests required**

- [x] Unit test check (tests to be done prior to handing to reviewer)
- [x] API endpoint testing

**Acceptance criteria**

- Unit test for reactivation logic check logic
  - call reactivation function with policy that is active and an error should be returned
  - call reactivation function with policy that has a status of cancelled and the reactivation should be triggered
  - call reactivation function with policy that has a status of lapsed and the reactivation should be triggered
  - call reactivation function with correct data and the `update_policy` action with reactivation data should be returned
- Using API endpoint test:
  - Issue policy, cancel, and reactivate
- Issuing from dashboard:
  - Issue policy from dashboard, cancel from dashboard dropdown, reactivate from dashboard dropdown, check that reactivation data is present on summary
 
**Link to a working quote, application, policy or claim - whichever is relevant to the part**

[Example Policy that was reactivated](https://app.rootplatform.com/orgs/24a7df4d-d88f-4468-af45-15979b4db5bd/insurance/policies/e16c90b0-c4ec-4044-bdb5-6c2f39e0285a)

### Authors considerations checklist

- [x] Has unit tests been written to prove the PR is working?
- [x] Is this PR being created into the correct branch (main or development)?

### Feedback and review

#### Were the specifications and Root guides clear enough?

Yes - but there is an error in the docs I believe

https://docs.rootplatform.com/reference/reactivate-1

Docs states that the property `type` is required but for reactivation it seems `reactivation_option_type` is required. 

#### What could have been explained better to make this part easier to understand?

N/A

### Part Specific Questions

**Question**
What other limits do you think would be useful to add to policy reactivation restrictions?

**Answer**
If health_checks were not done. 

