### PR TITLE
Part 6: Scheduled Functions and Anniversary Logic

### DIFF
--- a/dinosure_course_klensch/.root-config.json
+++ b/dinosure_course_klensch/.root-config.json
@@ -143,7 +143,25 @@
       "name": "Update Cover"
     }
   ],
-  "scheduledFunctions": [],
+  "scheduledFunctions": [
+    {
+      "functionName": "applyAnnualIncrease",
+      "policyStatuses": [
+        "not_taken_up",
+        "cancelled",
+        "active",
+        "lapsed",
+        "expired",
+        "pending_initial_payment"
+      ],
+      "frequency": {
+        "type": "yearly",
+        "timeOfDay": "04:00",
+        "dayOfMonth": 1,
+        "monthOfYear": "january"
+      }
+    }
+  ],
   "fulfillmentTypes": [
     {
       "key": "extraction",

--- a/dinosure_course_klensch/.root-config.json
+++ b/dinosure_course_klensch/.root-config.json
@@ -20,7 +20,7 @@
     "policySchemeType": "individual",
     "dashboardIssuingEnabled": true,
     "activatePoliciesOnEvent": "policy_issued",
-    "canReactivatePolicies": false,
+    "canReactivatePolicies": true,
     "notTakenUpEnabled": false,
     "welcomeLetterEnabled": true,
     "policyDocuments": [

--- a/dinosure_course_klensch/code/06-scheduled-functions.js
+++ b/dinosure_course_klensch/code/06-scheduled-functions.js
@@ -1,1 +1,45 @@
 // 06-scheduled-functions
+
+/**
+ * Executed on the schedule defined in `.root-config.json`.
+ * @param {object} params
+ * @param {PlatformPolicy} params.policy The policy for which the scheduled function is running.
+ * @param {PlatformPolicyholder} params.policyholder The policyholder linked to the policy
+ * @return {ProductModuleAction[] | void} The actions to be queued by the platform.
+ */
+const applyAnnualIncrease = ({ policy, policyholder }) => {
+  // policy younger than 1 year
+  if (calculateAge(policy.start_date) < 1) {
+    return;
+  }
+
+  const today = moment();
+
+  // if today is 1 January
+  if (today.month() === 0 && today.date() === 1) {
+    // increase cover by R10 000
+    const sumAssured = policy.sum_assured + 10000 * 100;
+
+    // calculate new premium
+    const newPremium = calculatePremium(
+      policy.module.birth_date,
+      sumAssured,
+      policy.module.species,
+      policy.module.health_checks_updated,
+    );
+
+    return [
+      {
+        name: 'update_policy',
+        data: {
+          monthlyPremium: newPremium,
+          sumAssured: sumAssured,
+          module: {
+            ...policy.module,
+            cover_amount: sumAssured,
+          },
+        },
+      },
+    ];
+  }
+};

--- a/dinosure_course_klensch/code/07-reactivation-flow.js
+++ b/dinosure_course_klensch/code/07-reactivation-flow.js
@@ -1,1 +1,54 @@
 // 07-reactivation-flow
+
+/**
+ * Get the reactivation options for inactive policies.
+ * @param {PlatformPolicy} policy The policy to be reactivated.
+ * @return {ReactivationOption[]} One of these options must be selected whenever an inactive policy is reactivated.
+ */
+const getReactivationOptions = (policy) => {
+  return [
+    new ReactivationOption({
+      type: 'reinstatement',
+      description:
+        'We will reinstate your policy and collect the outstanding premium from you.',
+      minimumBalanceRequired: false,
+      settlementAmount: 0,
+    }),
+  ];
+};
+
+/**
+ * Executed before a policy is reactivated.
+ * Can be used to prevent reactivation if certain conditions are not met.
+ * @param {object} params
+ * @param {PlatformPolicy} params.policy The policy to be reactivated
+ * @param {PlatformPolicyholder} params.policyholder The policyholder linked to the policy
+ * @param {ReactivationOption} params.reactivationOption The reactivation option selected
+ * @return {ProductModuleAction[] | void} The actions to be queued by the platform
+ */
+const beforePolicyReactivated = ({
+  policy,
+  policyholder,
+  reactivationOption,
+}) => {
+  const { status } = policy;
+  if (status !== 'cancelled' && status !== 'lapsed') {
+    throw new Error(
+      'This policy cannot be reactivated - it is not cancelled or lapsed status.',
+    );
+  }
+
+  const updatedModuleData = {
+    ...policy.module,
+    reactivation_date: moment().format(),
+  };
+
+  return [
+    {
+      name: 'update_policy',
+      data: {
+        module: updatedModuleData,
+      },
+    },
+  ];
+};

--- a/dinosure_course_klensch/code/unit-tests/04-reactivation-data.js
+++ b/dinosure_course_klensch/code/unit-tests/04-reactivation-data.js
@@ -1,0 +1,14 @@
+const reactivationPolicyActive = {
+  status: 'active',
+  module: {},
+};
+
+const reactivationPolicyLapsed = {
+  status: 'lapsed',
+  module: {},
+};
+
+const reactivationPolicyCancelled = {
+  status: 'cancelled',
+  module: {},
+};

--- a/dinosure_course_klensch/code/unit-tests/05-reactivation-tests.js
+++ b/dinosure_course_klensch/code/unit-tests/05-reactivation-tests.js
@@ -1,0 +1,81 @@
+/* global expect moment ReactivationOption InvalidRequestError AlteredPolicy AlterationPackage QuotePackage Application Policy generatePolicyNumber Joi RequotePolicy root */
+
+describe('Reactivation flow', () => {
+  // Setup
+  let reactivationOption;
+
+  before(() => {
+    // @ts-ignore
+    reactivationOption = getReactivationOptions(reactivationPolicyCancelled)[0];
+  });
+
+  // Quote hook
+  describe('Before reactivation', () => {
+    it('should return an error because the policy is already active', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyActive,
+          policyholder: null,
+          reactivationOption: null,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.not.equal(null);
+    });
+
+    it('should return without error: lapsed policy', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyLapsed,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+    });
+
+    it('should return without error: cancelled policy', () => {
+      let error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyCancelled,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+    });
+
+    it('should return update_action with the reactivation date', () => {
+      let error = null;
+      let actions = null;
+      try {
+        actions = beforePolicyReactivated({
+          // @ts-ignore
+          policy: reactivationPolicyCancelled,
+          policyholder: null,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+
+      // test that the actions return with the update_policy action and the reactivation date
+      expect(actions).to.not.equal(null);
+      expect(actions[0]).to.not.equal(null);
+      expect(actions[0].name).to.equal('update_policy');
+      expect(actions[0].data.module.reactivation_date).to.not.equal(null);
+    });
+  });
+});

--- a/dinosure_course_klensch/code/unit-tests/06-scheduled-functions-data.js
+++ b/dinosure_course_klensch/code/unit-tests/06-scheduled-functions-data.js
@@ -1,0 +1,27 @@
+const schedulePolicy = {
+  package_name: 'DinoSure',
+  sum_assured: 9000000,
+  base_premium: 145800,
+  monthly_premium: 145800,
+  start_date: moment(),
+  end_date: null,
+  module: {
+    start_date: moment().toDate(),
+    cover_amount: 9000000,
+    birth_date: moment().subtract(20, 'years').toDate(),
+    species: 'Tyrannosaurus Rex',
+    health_checks_updated: true,
+    dinosaur_name: 'James the Dinosaur',
+    dinosaur_colour: 'Lilac',
+    ndrn: '999999',
+  },
+};
+const schedulePolicy0 = {
+  ...schedulePolicy,
+  start_date: moment('2022-12-01'),
+};
+
+const schedulePolicy1 = {
+  ...schedulePolicy,
+  start_date: moment('2020-12-01'),
+};

--- a/dinosure_course_klensch/code/unit-tests/07-scheduled-functions-tests.js
+++ b/dinosure_course_klensch/code/unit-tests/07-scheduled-functions-tests.js
@@ -1,0 +1,67 @@
+describe('applyAnnualIncrease', () => {
+  let originalDateNow;
+
+  before(() => {
+    // store original Date.now
+    originalDateNow = Date.now;
+  });
+
+  after(() => {
+    // restore original Date.now
+    Date.now = originalDateNow;
+  });
+
+  it('should not trigger the function if policy is younger than 1 year old', () => {
+    Date.now = () => new Date('2023-01-01').getTime();
+
+    const result = applyAnnualIncrease({
+      // @ts-ignore
+      policy: schedulePolicy0,
+    });
+    expect(result).to.equal(undefined);
+  });
+
+  it('should not trigger the function if date is not 1st January', () => {
+    Date.now = () => new Date('2023-01-02').getTime();
+
+    const result = applyAnnualIncrease({
+      // @ts-ignore
+      policy: schedulePolicy0,
+    });
+
+    expect(result).to.equal(undefined);
+  });
+
+  it('should trigger the function if policy is older than 1 year old and date is 1st January', () => {
+    Date.now = () => new Date('2023-01-01').getTime();
+
+    const result = applyAnnualIncrease({
+      // @ts-ignore
+      policy: schedulePolicy1,
+    });
+    expect(result).to.not.equal(undefined);
+  });
+
+  it('should increase cover_amount to <R100000> and recalculate premium to <R1458.00>', () => {
+    Date.now = () => new Date('2023-01-01').getTime();
+
+    const result = applyAnnualIncrease({
+      // @ts-ignore
+      policy: schedulePolicy1,
+    });
+
+    expect(result).to.deep.equal([
+      {
+        name: 'update_policy',
+        data: {
+          sumAssured: 100000 * 100,
+          monthlyPremium: 145800,
+          module: {
+            ...schedulePolicy1.module,
+            cover_amount: 100000 * 100,
+          }
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION

### Which part of the onboarding is this for?

- [ ] Part 1: Getting Set Up with Your First Product
- [ ] Part 2: Generating Insurance Quotes
- [ ] Part 3: Issuing Policies
- [ ] Part 4: Amending Policies with Alteration Hooks
- [ ] Part 5: Lifecycle Hooks and Reactivation
- [x] Part 6: Scheduled Functions and Anniversary Logic
- [ ] Part 7: Crafting Documents and Documentation
- [ ] Part 8: Building a Claims and Payout Flow

### What has been implemented in this PR?

Add Annual Increase Function to Schedule Functions

### How was testing done?

**Types of tests required**

- [x] Unit test check (tests to be done prior to handing to reviewer)
- [ ] API endpoint testing

**Acceptance criteria**

- Unit test for annualIncrease logic
  - Using date-hacking, call applyIncrease function with current date set to something other than 1 January and nothing should be returned
  - Using date-hacking, call applyIncrease function with policy start date less than 1 year and nothing should return
  - Using date-hacking, call applyIncrease function with policy start date older than 1 year and date set to 1 January and test that cover_amount and premium were increased correctly
 

### Authors considerations checklist

- [x] Has unit tests been written to prove the PR is working?
- [x] Is this PR being created into the correct branch (main or development)?

### Feedback and review

#### Were the specifications and Root guides clear enough?

Yes

#### What could have been explained better to make this part easier to understand?

Where the date validation (for the correct date - 1 January) should occur, within the `applyIncrease` function or the `.root-config.json` - The root guides test cases + Root's YouTube videos on the topic seem to indicate in the function and in the config file. Is this a precautionary measure?

### Part Specific Questions

**Question**
What other uses can you think of for scheduled functions?

**Answer**
You can query an api checking if the health_checks_updated is `true`, and recalculate the premium based on the result. This could be the equivalent of checking if certain checks were completed on a yearly basis 
